### PR TITLE
Add CI for nbfmt

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,51 @@
+name: CI
+on: push
+
+jobs:
+  format_notebooks:
+    name: Format notebooks
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/setup-python@v1
+
+    - name: Checkout user/docs-l10n
+      uses: actions/checkout@v2
+      with:
+        path: docs-l10n
+
+    - name: Checkout tensorflow/docs
+      uses: actions/checkout@v2
+      with:
+        repository: tensorflow/docs
+        path: docs
+
+    - name: Set up environment
+      run: |
+        pip install --upgrade absl-py
+        cd ./docs-l10n && git fetch origin master:master
+        git config --global user.email "tfdocsbot+no-reply@gmail.com"
+        git config --global user.name "TF DocsBot"
+
+    - name: nbfmt
+      run: |
+        cd ./docs-l10n
+        echo "Run nbfmt.py on updated notebooks:"
+        NOTEBOOKS_CHANGED="$(git diff --name-only master | grep '\.ipynb$')"
+        if [[ -n "$NOTEBOOKS_CHANGED" ]]; then
+          python ../docs/tools/nbfmt.py --ignore_warn $NOTEBOOKS_CHANGED
+        fi
+
+    - name: Push changes
+      run: |
+        cd ./docs-l10n
+        MODIFIED_FILES=$(git ls-files --modified)
+        if [[ -n "$MODIFIED_FILES" ]]; then
+          echo "Commit formatting changes for:"
+          echo "$MODIFIED_FILES"
+          echo ""
+          git add $MODIFIED_FILES
+          if git commit -m "CI: nbfmt"; then
+            git push
+          fi
+        fi

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Please read the
 section in the
 [TensorFlow docs contributor guide](https://www.tensorflow.org/community/contribute/docs).
 
-General questions can be asked on the
+Ask general questions on the
 [docs@tensorflow.org list](https://groups.google.com/a/tensorflow.org/forum/#!forum/docs),
 and there are a few
 [language-specific docs lists](https://www.tensorflow.org/community/contribute/docs#community_translations)
 to help coordinate communities. If a language is gaining momentum and
-contributors and a new language-specific list would be useful, file
+contributors think a new language-specific list would be useful, file
 [a GitHub issue](https://github.com/tensorflow/docs-l10n/issues).
 
 ## Content


### PR DESCRIPTION
Auto-format notebooks using `nbfmt.py --ignore_warn`. This GitHub Action is triggered on push and will auto-add a commit by @tfdocsbot to the submitted pull request branch.

Tested here: https://github.com/lamberta/tf-docs-l10n/pull/4 ([actions log](https://github.com/lamberta/tf-docs-l10n/actions))

Will need to watch for how CLA bot reacts 🤖

Ref: https://github.com/tensorflow/docs-l10n/issues/128
