### PR TITLE
Add nbfmt to GitHub CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: CI
+on: pull_request
+
+jobs:
+  notebook_format:
+    name: Notebook format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - name: Fetch master branch
+      run: git fetch -u origin master:master
+    - name: Install nbfmt
+      run: |
+        pip install --upgrade absl-py
+        wget -P ./tools https://raw.githubusercontent.com/tensorflow/docs/master/tools/nbfmt.py
+    - name: Check notebook formatting
+      run: |
+        # Only check notebooks modified in this pull request.
+        notebooks="$(git diff --name-only master | grep '\.ipynb$' || true)"
+        if [[ -n "$notebooks" ]]; then
+          echo "Check formatting with nbfmt:"
+          python ./tools/nbfmt.py --test $notebooks
+        else
+          echo "No notebooks modified in this pull request."
+        fi


### PR DESCRIPTION
Sticking with what GitHub Actions is good at: pass/fail tests. Auto-commits would be nice, but adds complexity and this is enough to let contributors know there's more work to be done.

Tested:
- example good run: https://github.com/lamberta/tf-docs-l10n/runs/549994932
- example bad run: https://github.com/lamberta/tf-docs-l10n/runs/549999385
