### PR TITLE
Add nblint to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: CI
-on: pull_request
+on:
+  pull_request:
+    paths:
+    - "site/**"
+    - "!site/en-snapshot/**"
 
 jobs:
   notebook_format:
@@ -12,7 +16,7 @@ jobs:
       run: git fetch -u origin master:master
     - name: Install nbfmt
       run: |
-        pip install --upgrade absl-py
+        python3 -m pip install -U absl-py
         wget -P ./tools https://raw.githubusercontent.com/tensorflow/docs/master/tools/nbfmt.py
     - name: Check notebook formatting
       run: |
@@ -20,7 +24,31 @@ jobs:
         notebooks="$(git diff --name-only master | grep '\.ipynb$' || true)"
         if [[ -n "$notebooks" ]]; then
           echo "Check formatting with nbfmt:"
-          python ./tools/nbfmt.py --test $notebooks
+          python3 ./tools/nbfmt.py --test $notebooks
+        else
+          echo "No notebooks modified in this pull request."
+        fi
+
+  notebook_lint:
+    name: Notebook lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - name: Fetch master branch
+      run: git fetch -u origin master:master
+    - name: Install nblint
+      run: |
+        python3 -m pip install -U git+https://github.com/tensorflow/docs
+    - name: Lint notebooks
+      run: |
+        # Only check notebooks modified in this pull request.
+        notebooks="$(git diff --name-only master | grep '\.ipynb$' | grep -v 'en-snapshot' || true)"
+        if [[ -n "$notebooks" ]]; then
+          echo "Lint check with nblint:"
+          python3 -m tensorflow_docs.tools.nblint \
+            --styles=tensorflow,tensorflow_docs_l10n \
+            --arg=repo:tensorflow/docs-l10n $notebooks
         else
           echo "No notebooks modified in this pull request."
         fi


### PR DESCRIPTION
Here's a test pull request: https://github.com/lamberta/tf-docs-l10n/pull/9

Can see the (intentional) lint warning output [here](https://github.com/lamberta/tf-docs-l10n/pull/9/checks?check_run_id=801481179).
