### PR TITLE
Fix download buttons for nblint

### DIFF
--- a/site/el/guide/keras/masking_and_padding.ipynb
+++ b/site/el/guide/keras/masking_and_padding.ipynb
@@ -60,7 +60,7 @@
         "    Προβολή πηγαίου στο GitHub</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a target=\"_blank\" href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/e1/guide/keras/masking_and_padding.ipynb\">\n",
+        "    <a target=\"_blank\" href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/el/guide/keras/masking_and_padding.ipynb\">\n",
         "    <img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />\n",
         "    Λήψη \"σημειωματάριου\"</a>\n",
         "  </td>\n",

--- a/site/ja/guide/function.ipynb
+++ b/site/ja/guide/function.ipynb
@@ -63,6 +63,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/guide/function.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/guide/function.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/customization/basics.ipynb
+++ b/site/ja/tutorials/customization/basics.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/customization/basics.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/customization/basics.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/customization/custom_layers.ipynb
+++ b/site/ja/tutorials/customization/custom_layers.ipynb
@@ -62,7 +62,7 @@
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/customization/custom_layers.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/site/ja/tutorials/customization/custom_layers.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/customization/custom_layers.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
         "  </td>\n",
         "</table>"
       ]

--- a/site/ja/tutorials/images/cnn.ipynb
+++ b/site/ja/tutorials/images/cnn.ipynb
@@ -67,6 +67,9 @@
         "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
         "    View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/images/cnn.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/keras/classification.ipynb
+++ b/site/ja/tutorials/keras/classification.ipynb
@@ -95,6 +95,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/keras/overfit_and_underfit.ipynb
+++ b/site/ja/tutorials/keras/overfit_and_underfit.ipynb
@@ -95,6 +95,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/keras/overfit_and_underfit.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/keras/overfit_and_underfit.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/keras/regression.ipynb
+++ b/site/ja/tutorials/keras/regression.ipynb
@@ -95,6 +95,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/keras/regression.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/keras/regression.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/keras/save_and_load.ipynb
+++ b/site/ja/tutorials/keras/save_and_load.ipynb
@@ -95,6 +95,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/keras/save_and_load.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/keras/save_and_load.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/keras/text_classification.ipynb
+++ b/site/ja/tutorials/keras/text_classification.ipynb
@@ -95,6 +95,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/keras/text_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/keras/text_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/load_data/csv.ipynb
+++ b/site/ja/tutorials/load_data/csv.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/load_data/csv.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/load_data/csv.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/load_data/images.ipynb
+++ b/site/ja/tutorials/load_data/images.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/load_data/images.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/load_data/images.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/load_data/numpy.ipynb
+++ b/site/ja/tutorials/load_data/numpy.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/load_data/numpy.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/load_data/numpy.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/load_data/text.ipynb
+++ b/site/ja/tutorials/load_data/text.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/load_data/text.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/load_data/text.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/load_data/tfrecord.ipynb
+++ b/site/ja/tutorials/load_data/tfrecord.ipynb
@@ -53,6 +53,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/tutorials/load_data/tfrecord.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/load_data/tfrecord.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/tutorials/structured_data/feature_columns.ipynb
+++ b/site/ja/tutorials/structured_data/feature_columns.ipynb
@@ -67,6 +67,9 @@
         "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
         "    View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/tutorials/structured_data/feature_columns.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ja/xla/tutorials/xla_compile.ipynb
+++ b/site/ja/xla/tutorials/xla_compile.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ja/xla/tutorials/xla_compile.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ja/xla/tutorials/xla_compile.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/guide/data_performance.ipynb
+++ b/site/ko/guide/data_performance.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/guide/data_performance.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/guide/data_performance.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/guide/distributed_training.ipynb
+++ b/site/ko/guide/distributed_training.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/guide/distributed_training.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/guide/distributed_training.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/guide/eager.ipynb
+++ b/site/ko/guide/eager.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/guide/eager.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub)에서 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/guide/eager.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/guide/function.ipynb
+++ b/site/ko/guide/function.ipynb
@@ -63,6 +63,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/guide/function.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃헙(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/guide/function.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/guide/gpu.ipynb
+++ b/site/ko/guide/gpu.ipynb
@@ -53,6 +53,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/guide/gpu.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/guide/gpu.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/guide/keras/overview.ipynb
+++ b/site/ko/guide/keras/overview.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/guide/keras/overview.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/guide/keras/overview.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/guide/migrate.ipynb
+++ b/site/ko/guide/migrate.ipynb
@@ -59,6 +59,9 @@
         "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
         "    깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/guide/migrate.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/guide/saved_model.ipynb
+++ b/site/ko/guide/saved_model.ipynb
@@ -67,6 +67,9 @@
         "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
         "    깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/guide/saved_model.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/swift/tutorials/python_interoperability.ipynb
+++ b/site/ko/swift/tutorials/python_interoperability.ipynb
@@ -52,6 +52,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/swift/tutorials/python_interoperability.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub)에서 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/swift/tutorials/python_interoperability.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/swift/tutorials/raw_tensorflow_operators.ipynb
+++ b/site/ko/swift/tutorials/raw_tensorflow_operators.ipynb
@@ -52,6 +52,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/swift/tutorials/raw_tensorflow_operators.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub)소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/swift/tutorials/raw_tensorflow_operators.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/distribute/custom_training.ipynb
+++ b/site/ko/tutorials/distribute/custom_training.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/distribute/custom_training.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/distribute/custom_training.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/distribute/keras.ipynb
+++ b/site/ko/tutorials/distribute/keras.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/distribute/keras.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/distribute/keras.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/distribute/multi_worker_with_estimator.ipynb
+++ b/site/ko/tutorials/distribute/multi_worker_with_estimator.ipynb
@@ -53,6 +53,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/distribute/multi_worker_with_estimator.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/distribute/multi_worker_with_estimator.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/distribute/multi_worker_with_keras.ipynb
+++ b/site/ko/tutorials/distribute/multi_worker_with_keras.ipynb
@@ -53,6 +53,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/distribute/multi_worker_with_keras.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/distribute/multi_worker_with_keras.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/estimator/keras_model_to_estimator.ipynb
+++ b/site/ko/tutorials/estimator/keras_model_to_estimator.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/estimator/keras_model_to_estimator.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/estimator/keras_model_to_estimator.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/estimator/linear.ipynb
+++ b/site/ko/tutorials/estimator/linear.ipynb
@@ -53,6 +53,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/estimator/linear.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/estimator/linear.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/generative/adversarial_fgsm.ipynb
+++ b/site/ko/tutorials/generative/adversarial_fgsm.ipynb
@@ -55,6 +55,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/generative/adversarial_fgsm.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/generative/adversarial_fgsm.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/generative/dcgan.ipynb
+++ b/site/ko/tutorials/generative/dcgan.ipynb
@@ -67,6 +67,9 @@
         "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
         "    깃허브(GitHub)소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/generative/dcgan.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/generative/deepdream.ipynb
+++ b/site/ko/tutorials/generative/deepdream.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/generative/deepdream.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/generative/deepdream.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/generative/style_transfer.ipynb
+++ b/site/ko/tutorials/generative/style_transfer.ipynb
@@ -53,6 +53,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/generative/style_transfer.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/generative/style_transfer.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/images/cnn.ipynb
+++ b/site/ko/tutorials/images/cnn.ipynb
@@ -67,6 +67,9 @@
         "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
         "    깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/images/cnn.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/keras/classification.ipynb
+++ b/site/ko/tutorials/keras/classification.ipynb
@@ -95,6 +95,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/keras/classification.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/keras/overfit_and_underfit.ipynb
+++ b/site/ko/tutorials/keras/overfit_and_underfit.ipynb
@@ -95,6 +95,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/keras/overfit_and_underfit.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/keras/overfit_and_underfit.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/keras/regression.ipynb
+++ b/site/ko/tutorials/keras/regression.ipynb
@@ -95,6 +95,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/keras/regression.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/keras/regression.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/keras/save_and_load.ipynb
+++ b/site/ko/tutorials/keras/save_and_load.ipynb
@@ -95,6 +95,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/keras/save_and_load.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/keras/save_and_load.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/keras/text_classification.ipynb
+++ b/site/ko/tutorials/keras/text_classification.ipynb
@@ -95,6 +95,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/keras/text_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/keras/text_classification.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/keras/text_classification_with_hub.ipynb
+++ b/site/ko/tutorials/keras/text_classification_with_hub.ipynb
@@ -95,6 +95,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/keras/text_classification_with_hub.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/keras/text_classification_with_hub.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/load_data/unicode.ipynb
+++ b/site/ko/tutorials/load_data/unicode.ipynb
@@ -87,6 +87,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/load_data/unicode.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/load_data/unicode.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>\n"
       ]
     },

--- a/site/ko/tutorials/quickstart/advanced.ipynb
+++ b/site/ko/tutorials/quickstart/advanced.ipynb
@@ -63,6 +63,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/quickstart/advanced.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/quickstart/advanced.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/quickstart/beginner.ipynb
+++ b/site/ko/tutorials/quickstart/beginner.ipynb
@@ -63,6 +63,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/ko/tutorials/quickstart/beginner.ipynb\"><img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/quickstart/beginner.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/structured_data/feature_columns.ipynb
+++ b/site/ko/tutorials/structured_data/feature_columns.ipynb
@@ -67,6 +67,9 @@
         "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
         "    깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/structured_data/feature_columns.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/ko/tutorials/text/text_generation.ipynb
+++ b/site/ko/tutorials/text/text_generation.ipynb
@@ -59,6 +59,9 @@
         "    <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />\n",
         "    깃허브(GitHub) 소스 보기</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/ko/tutorials/text/text_generation.ipynb\"><img src=\"https://www.tensorflow.org/images/download_logo_32px.png\" />Download notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/zh-cn/tensorboard/get_started.ipynb
+++ b/site/zh-cn/tensorboard/get_started.ipynb
@@ -53,6 +53,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/zh-cn/tensorboard/get_started.ipynb\"><img src=\"https://tensorflow.google.cn/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/zh-cn/tensorboard/get_started.ipynb\"><img src=\"https://tensorflow.google.cn/images/download_logo_32px.png\" />下载此 notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/zh-cn/tensorboard/graphs.ipynb
+++ b/site/zh-cn/tensorboard/graphs.ipynb
@@ -53,6 +53,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/zh-cn/tensorboard/graphs.ipynb\"><img src=\"https://tensorflow.google.cn/images/GitHub-Mark-32px.png\" />在 GitHub 查看源代码</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/zh-cn/tensorboard/graphs.ipynb\"><img src=\"https://tensorflow.google.cn/images/download_logo_32px.png\" />下载此 notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/zh-cn/tensorboard/scalars_and_keras.ipynb
+++ b/site/zh-cn/tensorboard/scalars_and_keras.ipynb
@@ -53,6 +53,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/zh-cn/tensorboard/scalars_and_keras.ipynb\"><img src=\"https://tensorflow.google.cn/images/GitHub-Mark-32px.png\" />在 GitHub 上查看源代码</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/zh-cn/tensorboard/scalars_and_keras.ipynb\"><img src=\"https://tensorflow.google.cn/images/download_logo_32px.png\" />下载此 notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/zh-cn/tutorials/estimator/boosted_trees.ipynb
+++ b/site/zh-cn/tutorials/estimator/boosted_trees.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/zh-cn/tutorials/estimator/boosted_trees.ipynb\"><img src=\"https://tensorflow.google.cn/images/GitHub-Mark-32px.png\">在 GitHub 上查看源代码</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/zh-cn/tutorials/estimator/boosted_trees.ipynb\"><img src=\"https://tensorflow.google.cn/images/download_logo_32px.png\" />下载此 notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/zh-cn/tutorials/estimator/boosted_trees_model_understanding.ipynb
+++ b/site/zh-cn/tutorials/estimator/boosted_trees_model_understanding.ipynb
@@ -61,6 +61,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/zh-cn/tutorials/estimator/boosted_trees_model_understanding.ipynb\"><img src=\"https://tensorflow.google.cn/images/GitHub-Mark-32px.png\">在 GitHub 上查看源代码</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/zh-cn/tutorials/estimator/boosted_trees_model_understanding.ipynb\"><img src=\"https://tensorflow.google.cn/images/download_logo_32px.png\" />下载此 notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/zh-cn/tutorials/images/cnn.ipynb
+++ b/site/zh-cn/tutorials/images/cnn.ipynb
@@ -62,6 +62,9 @@
         "  <td>\n",
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/zh-cn/tutorials/images/cnn.ipynb\"><img src=\"https://tensorflow.google.cn/images/GitHub-Mark-32px.png\">在 GitHub 上查看源代码</a>\n",
         "  </td>\n",
+        "  <td>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/zh-cn/tutorials/images/cnn.ipynb\"><img src=\"https://tensorflow.google.cn/images/download_logo_32px.png\" />下载 notebook</a>\n",
+        "  </td>\n",
         "</table>"
       ]
     },

--- a/site/zh-cn/tutorials/load_data/csv.ipynb
+++ b/site/zh-cn/tutorials/load_data/csv.ipynb
@@ -62,7 +62,7 @@
         "    <a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/zh-cn/tutorials/load_data/csv.ipynb\"><img src=\"https://tensorflow.google.cn/images/GitHub-Mark-32px.png\" />在 Github 上查看源代码</a>\n",
         "  </td>\n",
         "  <td>\n",
-        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/site/zh-cn/tutorials/load_data/csv.ipynb\"><img src=\"https://tensorflow.google.cn/images/download_logo_32px.png\" />下载此 notebook</a>\n",
+        "    <a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/zh-cn/tutorials/load_data/csv.ipynb\"><img src=\"https://tensorflow.google.cn/images/download_logo_32px.png\" />下载此 notebook</a>\n",
         "  </td>\n",
         "</table>"
       ]


### PR DESCRIPTION
Run `nblint` on all translation notebooks and fix lint warnings. Ignore `site/en-snapshot` directory.

```
python3 -m tensorflow_docs.tools.nblint --styles=tensorflow,tensorflow_docs_l10n \
  --arg=repo:tensorflow/docs-l10n \
  site/!(en-snapshot)
```
