### PR TITLE
Enable postprocess_jupyter_notebooks_with_nbfmt_py (GitLocalize config)

### DIFF
--- a/.gitlocalize.yml
+++ b/.gitlocalize.yml
@@ -3,6 +3,7 @@ settings:
     - "true"
   mention_contributors_in_pull_requests:
     - "true"
+  postprocess_jupyter_notebooks_with_nbfmt_py: true
 
 synchronize:
   paths:


### PR DESCRIPTION
Enable GitLocalize config option that runs translated notebooks through nbfmt.py