### PR TITLE
Add auto-label workflow to GitHub Actions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,27 @@
+# Language labels
+ar:
+- site/ar/**
+el:
+- site/el/**
+es-419:
+- site/es-419/**
+fr:
+- site/fr/**
+id:
+- site/id/**
+it:
+- site/it/**
+ja:
+- site/ja/**
+ko:
+- site/ko/**
+pt-br:
+- site/pt-br/**
+ru:
+- site/ru/**
+tr:
+- site/tr/**
+vi:
+- site/vi/**
+zh-cn:
+- site/zh-cn/**

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,14 @@ on:
     - "!site/en-snapshot/**"
 
 jobs:
+  labeler:
+    # Label rules in .github/labeler.yml
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
   notebook_format:
     name: Notebook format
     runs-on: ubuntu-latest

--- a/.github/workflows/label-lgtm.yaml
+++ b/.github/workflows/label-lgtm.yaml
@@ -1,0 +1,43 @@
+# This workflow adds the community approval label ("lgtm") to pull requests.
+# It does *not* indicate maintainer approval. This a way to visually highlight
+# that someone/anyone thinks the pull request is ready for further review.
+# This event is triggered by a pull request approval, or simply a comment that
+# contains the text "lgtm".
+name: Community approval
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  approval:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check pull request approval
+      if: "contains(github.event.review.state, 'approved')"
+      env:
+        URL: "${{ github.event.pull_request.issue_url }}"
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          "${URL}/labels" \
+          --data '{"labels":["lgtm"]}'
+
+  lgtm:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check comment LGTM
+      # contains is case-insensitive.
+      if: "contains(github.event.comment.body, 'LGTM')"
+      env:
+        URL: "${{ github.event.issue.url }}"
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          "${URL}/labels" \
+          --data '{"labels":["lgtm"]}'


### PR DESCRIPTION
This replaces the auto-label functionality that @tfdocsbot currently provides. It's hopefully more maintainable than my own personal bot 🤖

It uses `actions/labeler@v2` to apply language labels based on directory.
And it adds the "lgtm" label to indicate *community approval* (not maintainer approval) through a pull request approval or a comment that contains "lgtm".

Tested here: https://github.com/lamberta/tf-docs-l10n/pull/14