### PR TITLE
Add CI check that translation source exists

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,9 @@ jobs:
         if [[ ${#changed_notebooks[@]} == 0 ]]; then
           echo "No notebooks modified in this pull request."
           exit 0
-        else
-          echo "Check formatting with nbfmt:"
-          python3 -m tensorflow_docs.tools.nbfmt --test "${changed_notebooks[@]}"
         fi
+        echo "Check formatting with nbfmt:"
+        python3 -m tensorflow_docs.tools.nbfmt --test "${changed_notebooks[@]}"
 
   nblint:
     name: Notebook lint
@@ -47,9 +46,39 @@ jobs:
         if [[ ${#changed_notebooks[@]} == 0 ]]; then
           echo "No notebooks modified in this pull request."
           exit 0
-        else
-          echo "Lint check with nblint:"
-          python3 -m tensorflow_docs.tools.nblint \
-            --styles=tensorflow,tensorflow_docs_l10n \
-            --arg=repo:tensorflow/docs-l10n "${changed_notebooks[@]}"
+        fi
+        echo "Lint check with nblint:"
+        python3 -m tensorflow_docs.tools.nblint \
+          --styles=tensorflow,tensorflow_docs_l10n \
+          --arg=repo:tensorflow/docs-l10n "${changed_notebooks[@]}"
+
+  sot-check:
+    name: Source doc check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fetch master branch
+      run: git fetch -u origin master:master
+    - name: Check for source doc
+      run: |
+        # Only check translations modified in this pull request.
+        readarray -t changed_files < <(git diff --name-only master \
+          | grep 'site/' | grep -v 'en-snapshot' | grep -v 'REVIEWERS' | grep -v 'README' || true)
+        if [[ ${#changed_files[@]} == 0 ]]; then
+          echo "No docs modified in this pull request."
+          exit 0
+        fi
+        # Check that each file has a counterpart in the site/en-snapshot directory.
+        declare -a orphan_files
+        for fp in "${changed_files[@]}"; do
+          # Get file path relative to translation root.
+          rel_fp="${fp#site/*/}"
+          if [[ ! -f "site/en-snapshot/$rel_fp" ]]; then
+            orphan_files+=("$fp")
+          fi
+        done
+        if [[ ${#orphan_files[@]} != 0 ]]; then
+          echo "No source counterpart in site/en-snapshot for the following files:"
+          printf -- "- %s\n" "${orphan_files[@]}"
+          exit 1
         fi


### PR DESCRIPTION
Require all submitted translation docs have a counterpart file in the `site/en-snapshot/` directory.

Tested in https://github.com/lamberta/tf-docs-l10n/pull/29
