### PR TITLE
Auto-label vendor reviewed translations

### DIFF
--- a/.github/workflows/bot-label-lgtm.yaml
+++ b/.github/workflows/bot-label-lgtm.yaml
@@ -3,12 +3,12 @@
 # someone in the world thinks the pull request is ready for further review. This
 # event is triggered by a pull request approval, or simply a comment that
 # contains the text "lgtm".
-# Webhook events: Issue comments, Pull request reviews
+# Webhook events: Pull request, Issue comments, Pull request reviews
 name: Community approval
 on:
   repository_dispatch:
-    # From: issue_comment, pull_request_review
-    types: [created, edited, submitted]
+    # From: pull_request, issue_comment, pull_request_review
+    types: [opened, created, edited, submitted]
 
 jobs:
   lgtm-comment:
@@ -46,3 +46,23 @@ jobs:
           -H "Authorization: token $GITHUB_TOKEN" \
           "${ISSUE_URL}/labels" \
           --data '{"labels":["lgtm"]}'
+
+  review-vendor:
+    # New pull requests already reviewed by vendors in GitLocalize.
+    if: >-
+      ${{ github.actor == 'tfdocsbot' &&
+          github.event.client_payload.action == 'opened' &&
+          github.event.client_payload.pull_request.user.login == 'gitlocalize-app[bot]' &&
+          contains(github.event.client_payload.pull_request.body, 'Translated by Alconost') }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add label
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ISSUE_URL: ${{ github.event.client_payload.pull_request.issue_url }}
+      run: |
+        curl -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token $GITHUB_TOKEN" \
+          "${ISSUE_URL}/labels" \
+          --data '{"labels":["lgtm-vendor"]}'


### PR DESCRIPTION
Auto-apply label to triage PRs that have been reviewed in [GitLocalize](https://gitlocalize.com/tensorflow/docs-l10n).

Tested in https://github.com/lamberta/tf-docs-l10n/pull/36

cc: @ilyaspiridonov 
