### PR TITLE
nblint fixes for site path

### DIFF
--- a/site/zh-cn/guide/advanced_autodiff.ipynb
+++ b/site/zh-cn/guide/advanced_autodiff.ipynb
@@ -52,7 +52,7 @@
       },
       "source": [
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td><a target=\"_blank\" href=\"https://tensorflow.google.cn/.*guide/advanced_autodiff\"><img src=\"https://tensorflow.google.cn/images/tf_logo_32px.png\" class=\"\"> 在  TensorFlow.org 上查看</a></td>\n",
+        "  <td><a target=\"_blank\" href=\"https://tensorflow.google.cn/guide/advanced_autodiff\"><img src=\"https://tensorflow.google.cn/images/tf_logo_32px.png\" class=\"\"> 在  TensorFlow.org 上查看</a></td>\n",
         "  <td><a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs-l10n/blob/master/site/zh-cn/guide/advanced_autodiff.ipynb\"><img src=\"https://tensorflow.google.cn/images/colab_logo_32px.png\" class=\"\">在 Google Colab 中运行 </a></td>\n",
         "  <td><a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/zh-cn/guide/advanced_autodiff.ipynb\"><img src=\"https://tensorflow.google.cn/images/GitHub-Mark-32px.png\" class=\"\"> 在 GitHub 上查看源代码</a></td>\n",
         "  <td><a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/zh-cn/guide/advanced_autodiff.ipynb\"><img src=\"https://tensorflow.google.cn/images/download_logo_32px.png\" class=\"\"> 下载笔记本</a></td>\n",

--- a/site/zh-cn/guide/checkpoint.ipynb
+++ b/site/zh-cn/guide/checkpoint.ipynb
@@ -52,7 +52,7 @@
       },
       "source": [
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td><a target=\"_blank\" href=\"https://tensorflow.google.cn/.*guide/checkpoint\"><img src=\"https://tensorflow.google.cn/images/tf_logo_32px.png\" class=\"\"> 在 TensorFlow.org 上查看</a></td>\n",
+        "  <td><a target=\"_blank\" href=\"https://tensorflow.google.cn/guide/checkpoint\"><img src=\"https://tensorflow.google.cn/images/tf_logo_32px.png\" class=\"\"> 在 TensorFlow.org 上查看</a></td>\n",
         "  <td><a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs-l10n/blob/master/site/zh-cn/guide/checkpoint.ipynb\"><img src=\"https://tensorflow.google.cn/images/colab_logo_32px.png\" class=\"\"> 在 Google Colab 中运行</a></td>\n",
         "  <td><a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/zh-cn/guide/checkpoint.ipynb\"><img src=\"https://tensorflow.google.cn/images/GitHub-Mark-32px.png\" class=\"\"> 在 GitHub 上查看源代码</a></td>\n",
         "  <td><a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/zh-cn/guide/checkpoint.ipynb\" class=\"\"><img src=\"https://tensorflow.google.cn/images/download_logo_32px.png\">下载笔记本</a></td>\n",

--- a/site/zh-cn/guide/data_performance.ipynb
+++ b/site/zh-cn/guide/data_performance.ipynb
@@ -52,7 +52,7 @@
       },
       "source": [
         "<table class=\"tfo-notebook-buttons\" align=\"left\">\n",
-        "  <td><a target=\"_blank\" href=\"https://tensorflow.google.cn/.*guide/data_performance\" class=\"\"><img src=\"https://tensorflow.google.cn/images/tf_logo_32px.png\" class=\"\">View on TensorFlow.org </a></td>\n",
+        "  <td><a target=\"_blank\" href=\"https://tensorflow.google.cn/guide/data_performance\" class=\"\"><img src=\"https://tensorflow.google.cn/images/tf_logo_32px.png\" class=\"\">View on TensorFlow.org </a></td>\n",
         "  <td><a target=\"_blank\" href=\"https://colab.research.google.com/github/tensorflow/docs-l10n/blob/master/site/zh-cn/guide/data_performance.ipynb\" class=\"\"><img src=\"https://tensorflow.google.cn/images/colab_logo_32px.png\" class=\"\">在 Google Colab 中运行</a></td>\n",
         "  <td><a target=\"_blank\" href=\"https://github.com/tensorflow/docs-l10n/blob/master/site/zh-cn/guide/data_performance.ipynb\" class=\"\"><img src=\"https://tensorflow.google.cn/images/GitHub-Mark-32px.png\" class=\"\">在 GitHub 上查看源代码</a></td>\n",
         "  <td><a href=\"https://storage.googleapis.com/tensorflow_docs/docs-l10n/site/zh-cn/guide/data_performance.ipynb\" class=\"\"><img src=\"https://tensorflow.google.cn/images/download_logo_32px.png\" class=\"\">下载笔记本</a></td>\n",


### PR DESCRIPTION
Found with `nblint`:
```
python3 -m tensorflow_docs.tools.nblint \
  --styles=tensorflow,tensorflow_docs_l10n \
  --arg=repo:tensorflow/docs-l10n \
  site/!(en-snapshot)
```