### PR TITLE
Fix little typo in docs-l10n/site/ko/tutorials/distribute/custom_training.ipynb

### DIFF
--- a/site/ko/tutorials/distribute/custom_training.ipynb
+++ b/site/ko/tutorials/distribute/custom_training.ipynb
@@ -324,7 +324,7 @@
         "`scale_loss = tf.reduce_sum(loss) * (1. / GLOBAL_BATCH_SIZE)`\n",
         "또는 `tf.nn.compute_average_loss` **함수를** 사용할 수도 있습니다. 이 함수는 **샘플당 손실과 선택적으로 샘플 가중치, GLOBAL_BATCH_SIZE를 매개변수 값으로 받고** 스케일이 조정된 손실을 반환합니다.\n",
         "\n",
-        "* 만약 규제 손실을 사용하는 모델이라면, 장치 개수로 손실 값을 스케일 조정해야 합니다. 이는 `tf.nn_scale_regularization_loss` 함수를 사용하여 처리할 수 있습니다.\n",
+        "* 만약 규제 손실을 사용하는 모델이라면, 장치 개수로 손실 값을 스케일 조정해야 합니다. 이는 `tf.nn.scale_regularization_loss` 함수를 사용하여 처리할 수 있습니다.\n",
         "\n",
         "* `tf.reduce_mean`을 사용하는 것은 추천하지 않습니다. 이렇게 하는 것은 손실을 실제 장치당 배치 크기로 나눕니다. 이 실제 장치당 배치 크기는 아마 각 단계(step)마다 크기가 다를 수 있습니다.\n",
         "\n",


### PR DESCRIPTION
Fix little typo in `docs-l10n/site/ko/tutorials/distribute/custom_training.ipynb`

`tf.nn_scale_regularization_loss` -> `tf.nn.scale_regularization_loss`