### PR TITLE
Fix typo of ci message

### DIFF
--- a/.github/workflows/bot-pr-new.yaml
+++ b/.github/workflows/bot-pr-new.yaml
@@ -58,7 +58,7 @@ jobs:
           msg+="Use the TensorFlow docs <a href='https://github.com/tensorflow/docs/tree/master/tools/tensorflow_docs/tools'>notebook tools</a> to format for consistent source diffs and lint for style:\n"
           msg+="<pre>\n$ python3 -m pip install -U --user git+https://github.com/tensorflow/docs\n<br/>"
           msg+="$ python3 -m tensorflow_docs.tools.nbfmt notebook.ipynb\n<br/>"
-          msg+="$ python3 -m tensorflow_docs.tools.nblint --arg=repo:tensorflow/docs-1l0n \ \n"
+          msg+="$ python3 -m tensorflow_docs.tools.nblint --arg=repo:tensorflow/docs-l10n \ \n"
           msg+="&nbsp;&nbsp;&nbsp;&nbsp;--styles=tensorflow,tensorflow_docs_l10n notebook.ipynb\n</pre>\n"
 
           msg+="If commits are added to the pull request, synchronize your local branch: <code>git pull origin $HEAD_REF</code>\n"


### PR DESCRIPTION
In this repo, the bot creates a message to format notebooks like https://github.com/tensorflow/docs-l10n/pull/498#issuecomment-808669230

In that message, I found a tiny typo and I fixed it.