### PR TITLE
fix a Japanese tutorial of classification with keras

### DIFF
--- a/site/ja/tutorials/keras/classification.ipynb
+++ b/site/ja/tutorials/keras/classification.ipynb
@@ -109,6 +109,7 @@
       "source": [
         "# TensorFlow and tf.keras\n",
         "import tensorflow as tf\n",
+        "from tensorflow import keras\n",
         "\n",
         "# Helper libraries\n",
         "import numpy as np\n",


### PR DESCRIPTION
I tried a Japanese tutorial of classification with keras.  
But it racks ```from tensorflow import keras```, so colab emits an error at 2nd code block.  
I added the import statement.  