### PR TITLE
Update tf2_arbitrary_image_stylization.ipynb

### DIFF
--- a/site/ko/hub/tutorials/tf2_arbitrary_image_stylization.ipynb
+++ b/site/ko/hub/tutorials/tf2_arbitrary_image_stylization.ipynb
@@ -107,7 +107,7 @@
         "print(\"TF Version: \", tf.__version__)\n",
         "print(\"TF-Hub version: \", hub.__version__)\n",
         "print(\"Eager mode enabled: \", tf.executing_eagerly())\n",
-        "print(\"GPU available: \", tf.test.is_gpu_available())"
+        "print(\"GPU available: \", tf.config.list_physical_devices('GPU'))"
       ]
     },
     {


### PR DESCRIPTION
Change code from 
tf.test.is_gpu_available()
to
tf.config.list_physical_devices('GPU'))

Which removes a deprecation warning. Tested the [updated .ipynb file](https://colab.research.google.com/gist/chunduriv/9a28deae427ea67361fb2e7c1940e7ef/tf2_arbitrary_image_stylization.ipynb).