### PR TITLE
Update tf2_image_retraining.ipynb

### DIFF
--- a/site/ja/hub/tutorials/tf2_image_retraining.ipynb
+++ b/site/ja/hub/tutorials/tf2_image_retraining.ipynb
@@ -106,7 +106,7 @@
         "\n",
         "print(\"TF version:\", tf.__version__)\n",
         "print(\"Hub version:\", hub.__version__)\n",
-        "print(\"GPU is\", \"available\" if tf.test.is_gpu_available() else \"NOT AVAILABLE\")"
+        "print(\"GPU is\", \"available\" if tf.config.list_physical_devices('GPU') else \"NOT AVAILABLE\")"
       ]
     },
     {
@@ -261,7 +261,7 @@
       "outputs": [],
       "source": [
         "model.compile(\n",
-        "  optimizer=tf.keras.optimizers.SGD(lr=0.005, momentum=0.9), \n",
+        "  optimizer=tf.keras.optimizers.SGD(learning_rate=0.005, momentum=0.9), \n",
         "  loss=tf.keras.losses.CategoricalCrossentropy(from_logits=True, label_smoothing=0.1),\n",
         "  metrics=['accuracy'])"
       ]


### PR DESCRIPTION
Changed `tf.test.is_gpu_available()` to `tf.config.list_physical_devices('GPU')`
Changed `lr` to `learning_rate`
Removes a deprecation warning. Tested the [updated .ipynb](https://colab.research.google.com/gist/chunduriv/1c4655040f81900f7f361ae1d187ae81/tf2_image_retraining.ipynb) file.