### PR TITLE
Replacing the depreciated package

### DIFF
--- a/site/ko/tutorials/customization/custom_layers.ipynb
+++ b/site/ko/tutorials/customization/custom_layers.ipynb
@@ -82,7 +82,7 @@
       },
       "outputs": [],
       "source": [
-        "print(tf.test.is_gpu_available())"
+        "print(tf.config.list_physical_devices('GPU'))"
       ]
     },
     {


### PR DESCRIPTION
replaced tf.test.is_gpu_available with tf.config.list_physical_devices('GPU') to list the GPU devices.