### PR TITLE
Fix from keras to tf.keras in a Japanese keras tutorial

### DIFF
--- a/site/ja/tutorials/keras/classification.ipynb
+++ b/site/ja/tutorials/keras/classification.ipynb
@@ -152,7 +152,7 @@
       },
       "outputs": [],
       "source": [
-        "fashion_mnist = keras.datasets.fashion_mnist\n",
+        "fashion_mnist = tf.keras.datasets.fashion_mnist\n",
         "\n",
         "(train_images, train_labels), (test_images, test_labels) = fashion_mnist.load_data()"
       ]


### PR DESCRIPTION
An error occurred because `keras` was used instead of `tf.keras`. 
So I fixed that.