### PR TITLE
Change `tf.keras.mixed_precision.experimental` to `tf.keras.mixed_pre…

### DIFF
--- a/site/ko/guide/mixed_precision.ipynb
+++ b/site/ko/guide/mixed_precision.ipynb
@@ -117,7 +117,7 @@
         "\n",
         "from tensorflow import keras\n",
         "from tensorflow.keras import layers\n",
-        "from tensorflow.keras.mixed_precision import experimental as mixed_precision"
+        "from tensorflow.keras import mixed_precision"
       ]
     },
     {
@@ -181,7 +181,7 @@
         "id": "54ecYY2Hn16E"
       },
       "source": [
-        "Keras에서 혼합 정밀도를 사용하려면 일반적으로 *dtype 정책*이라는  `tf.keras.mixed_precision.experimental.Policy`를 생성해야합니다. Dtype 정책은 레이어가 실행될 레이어를 지정합니다. 이 가이드에서는 `'mixed_float16'` 문자열로 정책을 구성하고 이를 전역 정책으로 설정합니다. 이로 인해 이후에 생성된 레이어가 float16과 float32를 혼합하여 혼합 정밀도를 사용합니다."
+        "Keras에서 혼합 정밀도를 사용하려면 일반적으로 *dtype 정책*이라는  `tf.keras.mixed_precision.Policy`를 생성해야합니다. Dtype 정책은 레이어가 실행될 레이어를 지정합니다. 이 가이드에서는 `'mixed_float16'` 문자열로 정책을 구성하고 이를 전역 정책으로 설정합니다. 이로 인해 이후에 생성된 레이어가 float16과 float32를 혼합하여 혼합 정밀도를 사용합니다."
       ]
     },
     {
@@ -193,7 +193,7 @@
       "outputs": [],
       "source": [
         "policy = mixed_precision.Policy('mixed_float16')\n",
-        "mixed_precision.set_policy(policy)"
+        "mixed_precision.set_global_policy(policy)"
       ]
     },
     {
@@ -652,7 +652,7 @@
         "id": "M2zpp7_65mTZ"
       },
       "source": [
-        "2 단계에서는 옵티마이저를 래핑하고 손실 조정을 적용하는 `tf.keras.mixed_precision.experimental.LossScaleOptimizer` 클래스를 사용합니다. 옵티마이저와 손실 조정이라는 두 가지 인수가 필요합니다. 동적 손실 규모를 사용하려면 다음과 같이 구성합니다"
+        "2 단계에서는 옵티마이저를 래핑하고 손실 조정을 적용하는 `tf.keras.mixed_precision.LossScaleOptimizer` 클래스를 사용합니다. 옵티마이저와 손실 조정이라는 두 가지 인수가 필요합니다. 동적 손실 규모를 사용하려면 다음과 같이 구성합니다"
       ]
     },
     {
@@ -870,14 +870,14 @@
         "- 컴퓨팅 능력이 7.0 이상인 TPU 또는 NVIDIA GPU를 사용하는 경우 성능이 최대 3배 향상되므로 혼합 정밀도를 사용해야 합니다.\n",
         "- 다음과 같이 혼합 정밀도를 사용할 수 있습니다.\n",
         "    ```\n",
-        "    # On TPUs, use 'mixed_bfloat16' instead policy = tf.keras.mixed_precision.experimental.Policy('mixed_float16') mixed_precision.set_policy(policy)\n",
+        "    # On TPUs, use 'mixed_bfloat16' instead policy = tf.keras.mixed_precision.Policy('mixed_float16') mixed_precision.set_policy(policy)\n",
         "    ```\n",
         "- 모델이 softmax로 끝나는 경우 float32인지 확인합니다. 모델이 무엇으로 끝나는지에 관계없이 출력이 float32인지 확인합니다.\n",
-        "- `mixed_float16` 으로 사용자 지정 훈련 루프를 사용하는 경우 위 코드 외에도 `tf.keras.mixed_precision.experimental.LossScaleOptimizer` 옵티 마이저를 래핑해야합니다. 그런 다음 `optimizer.get_scaled_loss`를 호출하여 손실을 조정하고 `optimizer.get_unscaled_gradients`를 사용하여 그래디언트의 조정을 해제합니다.\n",
+        "- `mixed_float16` 으로 사용자 지정 훈련 루프를 사용하는 경우 위 코드 외에도 `tf.keras.mixed_precision.LossScaleOptimizer` 옵티 마이저를 래핑해야합니다. 그런 다음 `optimizer.get_scaled_loss`를 호출하여 손실을 조정하고 `optimizer.get_unscaled_gradients`를 사용하여 그래디언트의 조정을 해제합니다.\n",
         "- 평가 정확도가 떨어지지 않으면 훈련 배치 크기를 두 배로 늘립니다\n",
         "- GPU에서 성능을 최대화하려면 대부분의 텐서 크기가 $8$의 배수가 되도록 합니다\n",
         "\n",
-        "`tf.keras.mixed_precision` API를 사용한 혼합 정밀도의 더 많은 예는 [공식 모델 저장소](https://github.com/tensorflow/models/tree/master/official)를 참조하세요. [ResNet](https://github.com/tensorflow/models/tree/master/official/vision/image_classification) 및 [Transformer](https://github.com/tensorflow/models/blob/master/official/nlp/transformer)와 같은 대부분의 공식 모델은 `--dtype=fp16`을 전달하여 혼합 정밀도로 실행됩니다.\n"
+        "`tf.keras.mixed_precision` API를 사용한 혼합 정밀도의 예는 [훈련 성능과 관련된 함수 및 클래스](https://github.com/tensorflow/models/blob/master/official/modeling/performance.py). 자세한 내용은 [Transformer](https://github.com/tensorflow/models/blob/master/official/nlp/modeling/layers/transformer_encoder_block.py)와 같은 공식 모델을 확인하세요.\n"
       ]
     }
   ],


### PR DESCRIPTION
…cision`

The `tf.keras.mixed_precision.experimental` API has been removed. The non-experimental symbols under `tf.keras.mixed_precision` have been available since TensorFlow 2.4 and should be used instead.