### PR TITLE
Refresh `zh-cn/hub/tutorials/spice.ipynb`

### DIFF
--- a/site/zh-cn/hub/tutorials/spice.ipynb
+++ b/site/zh-cn/hub/tutorials/spice.ipynb
@@ -83,7 +83,7 @@
       "outputs": [],
       "source": [
         "# All the imports to deal with sound data\n",
-        "!pip install pydub numba==0.48 librosa music21"
+        "!pip install pydub librosa music21"
       ]
     },
     {

--- a/site/zh-cn/hub/tutorials/spice.ipynb
+++ b/site/zh-cn/hub/tutorials/spice.ipynb
@@ -20,9 +20,7 @@
       },
       "outputs": [],
       "source": [
-        "#@title Copyright 2020 The TensorFlow Hub Authors. All Rights Reserved.\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+        "#@title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
         "# you may not use this file except in compliance with the License.\n",
         "# You may obtain a copy of the License at\n",
         "#\n",


### PR DESCRIPTION
This comes from tensorflow/hub, examples/colab/spice.ipynb.

Update is minor, but it's the fix for the notebook failure. Tested
locally.