### PR TITLE
Fix broken link in `transformer.ipynb`

### DIFF
--- a/site/ja/tutorials/text/transformer.ipynb
+++ b/site/ja/tutorials/text/transformer.ipynb
@@ -89,7 +89,7 @@
         "\n",
         "Transformerモデルは、[RNNs](text_classification_rnn.ipynb)や[CNNs](../images/intro_to_cnns.ipynb)の代わりに セルフアテンション・レイヤーを重ねたものを使って、可変長の入力を扱います。この一般的なアーキテクチャにはいくつもの利点があります。\n",
         "\n",
-        "* データの中の時間的／空間的な関係を前提にしません。これは、オブジェクトの集合（例えば、[StarCraftのユニット](https://deepmind.com/blog/alphastar-mastering-real-time-strategy-game-starcraft-ii/#block-8))を扱うには理想的です。\n",
+        "* データの中の時間的／空間的な関係を前提にしません。これは、オブジェクトの集合（例えば、[StarCraftのユニット](https://www.deepmind.com/blog/alphastar-mastering-the-real-time-strategy-game-starcraft-ii))を扱うには理想的です。\n",
         "* レイヤーの出力はRNNのような系列ではなく、並列に計算可能です。\n",
         "* たくさんのRNNのステップや畳み込み層を経ることなく、離れた要素どうしが互いの出力に影響を与えることができます（例えば、[Scene Memory Transformer](https://arxiv.org/pdf/1903.03878.pdf)を参照)。\n",
         "* 長距離の依存関係を学習可能です。これは、シーケンスを扱うタスクにおいては難しいことです。\n",

--- a/site/zh-cn/tutorials/text/transformer.ipynb
+++ b/site/zh-cn/tutorials/text/transformer.ipynb
@@ -92,7 +92,7 @@
         "\n",
         "一个 transformer 模型用自注意力层而非 [RNNs](text_classification_rnn.ipynb) 或 [CNNs](../images/intro_to_cnns.ipynb) 来处理变长的输入。这种通用架构有一系列的优势：\n",
         "\n",
-        "* 它不对数据间的时间/空间关系做任何假设。这是处理一组对象（objects）的理想选择（例如，[星际争霸单位（StarCraft units）](https://deepmind.com/blog/alphastar-mastering-real-time-strategy-game-starcraft-ii/#block-8)）。\n",
+        "* 它不对数据间的时间/空间关系做任何假设。这是处理一组对象（objects）的理想选择（例如，[星际争霸单位（StarCraft units）](https://www.deepmind.com/blog/alphastar-mastering-the-real-time-strategy-game-starcraft-ii)）。\n",
         "* 层输出可以并行计算，而非像 RNN 这样的序列计算。\n",
         "* 远距离项可以影响彼此的输出，而无需经过许多 RNN 步骤或卷积层（例如，参见[场景记忆 Transformer（Scene Memory Transformer）](https://arxiv.org/pdf/1903.03878.pdf)）\n",
         "* 它能学习长距离的依赖。在许多序列任务中，这是一项挑战。\n",


### PR DESCRIPTION
Fixed the broken link for StarCraft units in line 92.