### PR TITLE
[KO] Fix tutorial - quickstart

### DIFF
--- a/site/ko/tutorials/quickstart/beginner.ipynb
+++ b/site/ko/tutorials/quickstart/beginner.ipynb
@@ -155,12 +155,8 @@
         "  tf.keras.layers.Flatten(input_shape=(28, 28)),\n",
         "  tf.keras.layers.Dense(128, activation='relu'),\n",
         "  tf.keras.layers.Dropout(0.2),\n",
-        "  tf.keras.layers.Dense(10, activation='softmax')\n",
-        "])\n",
-        "\n",
-        "model.compile(optimizer='adam',\n",
-        "              loss='sparse_categorical_crossentropy',\n",
-        "              metrics=['accuracy'])"
+        "  tf.keras.layers.Dense(10)\n",
+        "]),
       ]
     },
     {


### PR DESCRIPTION
Fix: Korean tutorial was wrong. with English tutorial

Remove softmax activation of the last Dense layer: Later the guide use loss function with from_logits=True parameter. softmax activation should not be included in `model`.
Delete compile part: Later the guide has compile part again.