### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/site/en-snapshot/tensorboard/fairness-indicators.md
+++ b/site/en-snapshot/tensorboard/fairness-indicators.md
@@ -38,7 +38,6 @@ and plots files) and a `demo.py` utility from Google Cloud Platform,
 [here](https://console.cloud.google.com/storage/browser/tensorboard_plugin_fairness_indicators/)
 using following command.
 ```
-pip install gsutil
 gcloud storage cp --recursive gs://tensorboard_plugin_fairness_indicators/ .
 ```
 

--- a/site/es-419/tensorboard/fairness-indicators.md
+++ b/site/es-419/tensorboard/fairness-indicators.md
@@ -25,7 +25,6 @@ pip install tensorboard-plugin-fairness-indicators
 Si desea probar los indicadores de equidad en TensorBoard, puede descargar los resultados de la evaluación del análisis de modelos de TensorFlow como muestra (archivos eval_config.json, métricas y gráficas) y una utilidad `demo.py` de la Plataforma Google Cloud, [aquí](https://console.cloud.google.com/storage/browser/tensorboard_plugin_fairness_indicators/) utilizando el siguiente comando.
 
 ```
-pip install gsutil
 gcloud storage cp --recursive gs://tensorboard_plugin_fairness_indicators/ .
 ```
 

--- a/site/ja/tensorboard/fairness-indicators.md
+++ b/site/ja/tensorboard/fairness-indicators.md
@@ -25,7 +25,6 @@ pip install tensorboard-plugin-fairness-indicators
 TensorBoard でフェアネスインジケータをテストするには、サンプルの TensorFlow Model Analysis 評価結果（eval_config.json、メトリック、プロットファイル）と Google Cloud Platform の `demo.py` ユーティリティを、次のコマンドを使って[ここ](https://console.cloud.google.com/storage/browser/tensorboard_plugin_fairness_indicators/)からダウンロードできます。
 
 ```
-pip install gsutil
 gcloud storage cp --recursive gs://tensorboard_plugin_fairness_indicators/ .
 ```
 

--- a/site/ja/tfx/guide/container_component.md
+++ b/site/ja/tfx/guide/container_component.md
@@ -45,8 +45,8 @@ grep_component = tfx.dsl.components.create_container_component(
     parameters={
         'pattern': str,
     },
-    # The component code uses gsutil to upload the data to Google Cloud Storage, so the
-    # container image needs to have gsutil installed and configured.
+    # The component code uses gcloud storage to upload the data to Google Cloud Storage, so the
+    # container image needs to have gcloud storage installed and configured.
     image='google/cloud-sdk:278.0.0',
     command=[
         'sh', '-exc',

--- a/site/ko/tensorboard/fairness-indicators.md
+++ b/site/ko/tensorboard/fairness-indicators.md
@@ -25,7 +25,6 @@ pip install tensorboard-plugin-fairness-indicators
 TensorBoard에서 Fairness Indicators를 테스트하려면 Google 클라우드 플랫폼에서 TensorFlow 모델 분석의 평가 결과 샘플(eval_config.json, 메트릭 및 플롯 파일)과 `demo.py` 유틸리티를 다운로드할 수 있습니다(다음 명령을 사용하여 [여기](https://console.cloud.google.com/storage/browser/tensorboard_plugin_fairness_indicators/)에서 다운로드).
 
 ```
-pip install gsutil
 gcloud storage cp --recursive gs://tensorboard_plugin_fairness_indicators/ .
 ```
 

--- a/site/pt-br/tensorboard/fairness-indicators.md
+++ b/site/pt-br/tensorboard/fairness-indicators.md
@@ -25,7 +25,6 @@ pip install tensorboard-plugin-fairness-indicators
 Se você quiser testar Fairness Indicators no TensorBoard, pode baixar os resultados de avaliação de amostra da TensorFlow Model Analysis (eval_config.json, métricas e arquivos de plotagens), ou Análise de Modelo do TensorFlow, e um utilitário `demo.py` do Google Cloud Platform, [aqui](https://console.cloud.google.com/storage/browser/tensorboard_plugin_fairness_indicators/), usando o comando a seguir.
 
 ```
-pip install gsutil
 gcloud storage cp --recursive gs://tensorboard_plugin_fairness_indicators/ .
 ```
 

--- a/site/zh-cn/tensorboard/fairness-indicators.md
+++ b/site/zh-cn/tensorboard/fairness-indicators.md
@@ -25,7 +25,6 @@ pip install tensorboard-plugin-fairness-indicators
 如果想要在 TensorBoard 中测试 Fairness Indicators，您可以使用以下命令从 Google Cloud Platform（[此处](https://console.cloud.google.com/storage/browser/tensorboard_plugin_fairness_indicators/)）下载 TensorFlow Model Analysis 评估结果示例（eval_config.json、指标和图文件）以及 `demo.py` 实用工具。
 
 ```
-pip install gsutil
 gcloud storage cp --recursive gs://tensorboard_plugin_fairness_indicators/ .
 ```
 


### PR DESCRIPTION
This PR completes the migration from legacy `gsutil` to `gcloud storage` in `tensorflow/docs-l10n`.

### Summary of Changes:
1. **`site/ja/tfx/guide/container_component.md`**:
   - Updates the container component documentation comment from `gsutil` to `gcloud storage` to reflect the code below it (`gcloud storage cp`) and maintain consistency with other language translations (`en-snapshot`, `ko`, `pt-br`, `zh-cn`).
2. **`site/*/tensorboard/fairness-indicators.md`**:
   - Removes obsolete `pip install gsutil` instruction preceding the already-migrated `gcloud storage cp --recursive` command across all language versions.

#gsutil-migration
